### PR TITLE
Allow providing express instance

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -90,8 +90,8 @@ function setupProxies(server, app, options) {
 }
 
 module.exports = exports = function server(opts, callback) {
-    var app = express();
     var options = combineDefaults(opts);
+    var app = options.app || express();
 
     createServer(options, app, function (err, server) {
         if (err) {


### PR DESCRIPTION
This is important because of ordering of specific middleware, which is important to express. This allows us to set up cors, or other middleware handlers prior to stupid-server setting up serve-index and serve-static.